### PR TITLE
Correct the 4th parameter of extcodecopy to length instead of end

### DIFF
--- a/src/lib/ERC6551AccountLib.sol
+++ b/src/lib/ERC6551AccountLib.sol
@@ -39,7 +39,7 @@ library ERC6551AccountLib {
 
         assembly {
             // copy 0x60 bytes from end of footer
-            extcodecopy(address(), add(footer, 0x20), 0x4d, 0xad)
+            extcodecopy(address(), add(footer, 0x20), 0x4d, 0x60)
         }
 
         return abi.decode(footer, (uint256, address, uint256));
@@ -50,7 +50,7 @@ library ERC6551AccountLib {
 
         assembly {
             // copy 0x20 bytes from beginning of footer
-            extcodecopy(address(), add(footer, 0x20), 0x2d, 0x4d)
+            extcodecopy(address(), add(footer, 0x20), 0x2d, 0x20)
         }
 
         return abi.decode(footer, (uint256));


### PR DESCRIPTION
Per the description of EVM opcode EXTCODECOPY, the 4th parameter should be the "length" of bytes to copy from the source code.
https://ethervm.io/#3C

As we want to copy 0x60 bytes from the source contract, we need to put 0x60 as the 4th parameter instead the end offset "0xad". The same applies to parsing salt.