### PR TITLE
Specify compiler + optimizer runs explicitly

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,10 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 
+solc = "0.8.17"
+optimizer = true
+optimizer_runs = 200
+
 [rpc_endpoints]
 goerli = "${GOERLI_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"


### PR DESCRIPTION
This PR ensures that ERC6551 Registries deployed on other chains use the same compiler version and optimization runs such that the address is kept the same.