### PR TITLE
Enable authenticated initialization of accounts

### DIFF
--- a/src/examples/initializable/InitializableERC6551Account.sol
+++ b/src/examples/initializable/InitializableERC6551Account.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/console.sol";
+
+import "../simple/SimpleERC6551Account.sol";
+import "openzeppelin-contracts/token/ERC721/IERC721.sol";
+import "openzeppelin-contracts/metatx/ERC2771Context.sol";
+
+contract InitializableERC6551Account is SimpleERC6551Account, ERC2771Context {
+    address public creator;
+
+    constructor(address registry) ERC2771Context(registry) {}
+
+    function initialize() public {
+        (, address tokenContract, uint256 tokenId) = ERC6551AccountLib.token();
+        address _creator = _msgSender();
+
+        require(
+            _creator == IERC721(tokenContract).ownerOf(tokenId),
+            "Only initializable by token holder"
+        );
+
+        creator = _creator;
+    }
+}

--- a/test/ERC6551Registry.t.sol
+++ b/test/ERC6551Registry.t.sol
@@ -24,7 +24,7 @@ contract RegistryTest is Test {
         uint256 salt = 400;
         address deployedAccount;
 
-        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("InitializationFailed()"))));
+        vm.expectRevert("disabled");
         deployedAccount = registry.createAccount(
             address(implementation),
             chainId,

--- a/test/examples/initializable/InitializableERC6551Account.sol
+++ b/test/examples/initializable/InitializableERC6551Account.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import "../../../src/ERC6551Registry.sol";
+import "../../../src/examples/initializable/InitializableERC6551Account.sol";
+import "../../mocks/MockERC721.sol";
+import "../../mocks/MockERC6551Account.sol";
+
+contract InitializableERC6551AccountTest is Test {
+    ERC6551Registry public registry;
+    InitializableERC6551Account public implementation;
+    MockERC721 nft = new MockERC721();
+
+    function setUp() public {
+        registry = new ERC6551Registry();
+        implementation = new InitializableERC6551Account(address(registry));
+    }
+
+    function testAuthenticatedDeploy() public {
+        nft.mint(vm.addr(1), 1);
+
+        // initialization reverts if not called by token holder
+        vm.expectRevert("Only initializable by token holder");
+        registry.createAccount(
+            address(implementation),
+            block.chainid,
+            address(nft),
+            1,
+            0,
+            abi.encodeWithSignature("initialize()")
+        );
+
+        vm.prank(vm.addr(1));
+        address deployedAccount = registry.createAccount(
+            address(implementation),
+            block.chainid,
+            address(nft),
+            1,
+            0,
+            abi.encodeWithSignature("initialize()")
+        );
+
+        assertTrue(deployedAccount != address(0));
+
+        address predictedAccount = registry.account(
+            address(implementation),
+            block.chainid,
+            address(nft),
+            1,
+            0
+        );
+
+        assertEq(predictedAccount, deployedAccount);
+
+        assertEq(InitializableERC6551Account(payable(deployedAccount)).creator(), vm.addr(1));
+    }
+}


### PR DESCRIPTION
This PR modifies the ERC-6551 Registry contract to append `msg.sender` to `initData` prior to calling into to the created account contract. It also changes the error handling logic to bubble up any revert messages from the account contract rather than reverting with a custom error. Finally, it adds an example account implementation showing how to permit initialization only by the current token holder.

These changes allow account implementations that wish to authenticate callers from within the account's initialization function to do so using an ERC-2771 style `_msgSender()` check.