### PR TITLE
Improve hardhat support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
-  "name": "@erc6551/reference",
-  "version": "0.0.1",
-  "files": [
-    "/src/**/*.sol",
-    "/out/**/*.json"
-  ],
+  "name": "erc6551-reference",
+  "version": "0.2.0",
   "scripts": {
     "test": "forge test",
     "prettier": "prettier --write '{**/*,*}.{js,ts,tsx,md,mdx,yml,sol}'",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 sstore2/=lib/sstore2/contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,3 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
-sstore2/=lib/sstore2/contracts/
+@openzeppelin/=lib/openzeppelin-contracts/

--- a/script/ComputeRegistryAddress.s.sol
+++ b/script/ComputeRegistryAddress.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "openzeppelin-contracts/utils/Create2.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 
 import "../src/ERC6551Registry.sol";
 

--- a/script/DeployRegistry.s.sol
+++ b/script/DeployRegistry.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "openzeppelin-contracts/utils/Create2.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 
 import "../src/ERC6551Registry.sol";
 

--- a/src/ERC6551Registry.sol
+++ b/src/ERC6551Registry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/utils/Create2.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 
 import "./interfaces/IERC6551Registry.sol";
 import "./lib/ERC6551BytecodeLib.sol";

--- a/src/examples/simple/SimpleERC6551Account.sol
+++ b/src/examples/simple/SimpleERC6551Account.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/utils/introspection/IERC165.sol";
-import "openzeppelin-contracts/token/ERC721/IERC721.sol";
-import "openzeppelin-contracts/interfaces/IERC1271.sol";
-import "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 import "../../interfaces/IERC6551Account.sol";
 import "../../lib/ERC6551AccountLib.sol";

--- a/src/examples/upgradeable/ERC6551AccountProxy.sol
+++ b/src/examples/upgradeable/ERC6551AccountProxy.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/proxy/ERC1967/ERC1967Upgrade.sol";
-import "openzeppelin-contracts/proxy/Proxy.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
+import "@openzeppelin/contracts/proxy/Proxy.sol";
 
 error InvalidImplementation();
 

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 /// @author: manifold.xyz
 
-import "openzeppelin-contracts/interfaces/IERC1271.sol";
-import "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
-import "openzeppelin-contracts/utils/introspection/IERC165.sol";
-import "openzeppelin-contracts/utils/introspection/ERC165Checker.sol";
-import "openzeppelin-contracts/utils/StorageSlot.sol";
-import "openzeppelin-contracts/token/ERC721/IERC721.sol";
-import "openzeppelin-contracts/token/ERC721/IERC721Receiver.sol";
-import "openzeppelin-contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts/utils/StorageSlot.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
 import "../../interfaces/IERC6551Account.sol";
 import "../../lib/ERC6551AccountLib.sol";

--- a/src/lib/ERC6551AccountLib.sol
+++ b/src/lib/ERC6551AccountLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/utils/Create2.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 import "./ERC6551BytecodeLib.sol";
 
 library ERC6551AccountLib {

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@erc6551/reference",
+  "version": "0.2.0",
+  "files": [
+    "**/*.sol"
+  ],
+  "description": "ERC-6551 reference implementation"
+}

--- a/test/mocks/MockERC1155.sol
+++ b/test/mocks/MockERC1155.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 
 contract MockERC1155 is ERC1155 {
     constructor() ERC1155("") {}

--- a/test/mocks/MockERC6551Account.sol
+++ b/test/mocks/MockERC6551Account.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import "../../src/interfaces/IERC6551Account.sol";
 import "../../src/lib/ERC6551AccountLib.sol";

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract MockERC721 is ERC721 {
     constructor() ERC721("MockERC721", "M721") {}


### PR DESCRIPTION
This PR makes it easier for this repo to be included as a dependency in hardhat projects without modifying the hardhat configuration. It does so by matching the import paths for all OpenZeppelin imports and packaging the `src/` directory as its own NPM package.