### PR TITLE
Making examples' functions virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ For more information on writing and running tests, refer to the [Foundry testing
 
 ## History
 
-**0.2.2**
+**0.2.1**
 
 - Making examples' functions `virtual` and `public` so that the examples can be used as a base for more advanced contracts

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ For more information on writing and running tests, refer to the [Foundry testing
 
 **0.2.2**
 
-- Making examples' functions `virtual` so that the examples can be used as a base for more advanced contracts
+- Making examples' functions `virtual` and `public` so that the examples can be used as a base for more advanced contracts

--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ forge test
 ```
 
 For more information on writing and running tests, refer to the [Foundry testing guide](https://github.com/foundry-rs/book/blob/master/src/forge/writing-tests.md).
+
+
+## History
+
+**0.2.1**
+
+- Making examples' functions `virtual` so that the examples can be used as a base for more advanced contracts

--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ For more information on writing and running tests, refer to the [Foundry testing
 
 ## History
 
-**0.2.1**
+**0.2.2**
 
 - Making examples' functions `virtual` so that the examples can be used as a base for more advanced contracts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc6551-reference",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "test": "forge test",
     "prettier": "prettier --write '{**/*,*}.{js,ts,tsx,md,mdx,yml,sol}'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc6551-reference",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "scripts": {
     "test": "forge test",
     "prettier": "prettier --write '{**/*,*}.{js,ts,tsx,md,mdx,yml,sol}'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc6551-reference",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "test": "forge test",
     "prettier": "prettier --write '{**/*,*}.{js,ts,tsx,md,mdx,yml,sol}'",

--- a/src/examples/simple/SimpleERC6551Account.sol
+++ b/src/examples/simple/SimpleERC6551Account.sol
@@ -19,7 +19,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         uint256 value,
         bytes calldata data,
         uint256 operation
-    ) external payable returns (bytes memory result) {
+    ) external payable virtual returns (bytes memory result) {
         require(_isValidSigner(msg.sender), "Invalid signer");
         require(operation == 0, "Only call operations are supported");
 
@@ -35,7 +35,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         }
     }
 
-    function isValidSigner(address signer, bytes calldata) external view returns (bytes4) {
+    function isValidSigner(address signer, bytes calldata) external view virtual returns (bytes4) {
         if (_isValidSigner(signer)) {
             return IERC6551Account.isValidSigner.selector;
         }
@@ -46,6 +46,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
     function isValidSignature(bytes32 hash, bytes memory signature)
         external
         view
+        virtual
         returns (bytes4 magicValue)
     {
         bool isValid = SignatureChecker.isValidSignatureNow(owner(), hash, signature);
@@ -57,7 +58,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         return "";
     }
 
-    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure virtual returns (bool) {
         return (interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC6551Account).interfaceId ||
             interfaceId == type(IERC6551Executable).interfaceId);
@@ -66,6 +67,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
     function token()
         public
         view
+        virtual
         returns (
             uint256,
             address,
@@ -81,14 +83,14 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         return abi.decode(footer, (uint256, address, uint256));
     }
 
-    function owner() public view returns (address) {
+    function owner() public view virtual returns (address) {
         (uint256 chainId, address tokenContract, uint256 tokenId) = token();
         if (chainId != block.chainid) return address(0);
 
         return IERC721(tokenContract).ownerOf(tokenId);
     }
 
-    function _isValidSigner(address signer) internal view returns (bool) {
+    function _isValidSigner(address signer) internal view virtual returns (bool) {
         return signer == owner();
     }
 }

--- a/src/examples/simple/SimpleERC6551Account.sol
+++ b/src/examples/simple/SimpleERC6551Account.sol
@@ -19,7 +19,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         uint256 value,
         bytes calldata data,
         uint256 operation
-    ) external payable virtual returns (bytes memory result) {
+    ) public payable virtual returns (bytes memory result) {
         require(_isValidSigner(msg.sender), "Invalid signer");
         require(operation == 0, "Only call operations are supported");
 
@@ -35,7 +35,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         }
     }
 
-    function isValidSigner(address signer, bytes calldata) external view virtual returns (bytes4) {
+    function isValidSigner(address signer, bytes calldata) public view virtual returns (bytes4) {
         if (_isValidSigner(signer)) {
             return IERC6551Account.isValidSigner.selector;
         }
@@ -44,7 +44,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature)
-        external
+        public
         view
         virtual
         returns (bytes4 magicValue)
@@ -58,7 +58,7 @@ contract SimpleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Exe
         return "";
     }
 
-    function supportsInterface(bytes4 interfaceId) external pure virtual returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
         return (interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC6551Account).interfaceId ||
             interfaceId == type(IERC6551Executable).interfaceId);

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -120,7 +120,7 @@ contract ERC6551AccountUpgradeable is
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 
-    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
         return (interfaceId == type(IERC6551Account).interfaceId ||
             interfaceId == type(IERC6551Executable).interfaceId ||
             interfaceId == type(IERC1155Receiver).interfaceId ||

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -48,7 +48,7 @@ contract ERC6551AccountUpgradeable is
         uint256 _value,
         bytes calldata _data,
         uint256 _operation
-    ) external payable override returns (bytes memory _result) {
+    ) external payable virtual override returns (bytes memory _result) {
         require(_isValidSigner(msg.sender), "Caller is not owner");
         require(_operation == 0, "Only call operations are supported");
         ++state;
@@ -62,7 +62,7 @@ contract ERC6551AccountUpgradeable is
     /**
      * @dev Upgrades the implementation.  Only the token owner can call this.
      */
-    function upgrade(address implementation_) external {
+    function upgrade(address implementation_) external virtual {
         require(_isValidSigner(msg.sender), "Caller is not owner");
         require(implementation_ != address(0), "Invalid implementation address");
         ++state;
@@ -71,7 +71,7 @@ contract ERC6551AccountUpgradeable is
 
     function isValidSignature(bytes32 hash, bytes memory signature)
         external
-        view
+        view virtual
         returns (bytes4 magicValue)
     {
         bool isValid = SignatureChecker.isValidSignatureNow(owner(), hash, signature);
@@ -82,7 +82,7 @@ contract ERC6551AccountUpgradeable is
         return "";
     }
 
-    function isValidSigner(address signer, bytes calldata) external view returns (bytes4) {
+    function isValidSigner(address signer, bytes calldata) external view virtual returns (bytes4) {
         if (_isValidSigner(signer)) {
             return IERC6551Account.isValidSigner.selector;
         }
@@ -95,7 +95,7 @@ contract ERC6551AccountUpgradeable is
         address,
         uint256 receivedTokenId,
         bytes memory
-    ) external view returns (bytes4) {
+    ) external view virtual returns (bytes4) {
         _revertIfOwnershipCycle(msg.sender, receivedTokenId);
         return IERC721Receiver.onERC721Received.selector;
     }
@@ -106,7 +106,7 @@ contract ERC6551AccountUpgradeable is
         uint256,
         uint256,
         bytes memory
-    ) external pure returns (bytes4) {
+    ) external pure virtual returns (bytes4) {
         return IERC1155Receiver.onERC1155Received.selector;
     }
 
@@ -116,7 +116,7 @@ contract ERC6551AccountUpgradeable is
         uint256[] memory,
         uint256[] memory,
         bytes memory
-    ) external pure returns (bytes4) {
+    ) external pure virtual returns (bytes4) {
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 
@@ -133,7 +133,7 @@ contract ERC6551AccountUpgradeable is
      */
     function token()
         public
-        view
+        view virtual
         override
         returns (
             uint256,
@@ -147,13 +147,13 @@ contract ERC6551AccountUpgradeable is
     /**
      * @dev {See IERC6551Account-owner}
      */
-    function owner() public view returns (address) {
+    function owner() public view virtual returns (address) {
         (uint256 chainId, address contractAddress, uint256 tokenId) = token();
         if (chainId != block.chainid) return address(0);
         return IERC721(contractAddress).ownerOf(tokenId);
     }
 
-    function _isValidSigner(address signer) internal view returns (bool) {
+    function _isValidSigner(address signer) internal view virtual returns (bool) {
         return signer == owner();
     }
 
@@ -164,7 +164,7 @@ contract ERC6551AccountUpgradeable is
      */
     function _revertIfOwnershipCycle(address receivedTokenAddress, uint256 receivedTokenId)
         internal
-        view
+        view virtual
     {
         (uint256 _chainId, address _contractAddress, uint256 _tokenId) = token();
         require(

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -48,7 +48,7 @@ contract ERC6551AccountUpgradeable is
         uint256 _value,
         bytes calldata _data,
         uint256 _operation
-    ) external payable virtual override returns (bytes memory _result) {
+    ) public payable virtual override returns (bytes memory _result) {
         require(_isValidSigner(msg.sender), "Caller is not owner");
         require(_operation == 0, "Only call operations are supported");
         ++state;
@@ -62,7 +62,7 @@ contract ERC6551AccountUpgradeable is
     /**
      * @dev Upgrades the implementation.  Only the token owner can call this.
      */
-    function upgrade(address implementation_) external virtual {
+    function upgrade(address implementation_) public virtual {
         require(_isValidSigner(msg.sender), "Caller is not owner");
         require(implementation_ != address(0), "Invalid implementation address");
         ++state;
@@ -70,7 +70,7 @@ contract ERC6551AccountUpgradeable is
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature)
-        external
+        public
         view virtual
         returns (bytes4 magicValue)
     {
@@ -82,7 +82,7 @@ contract ERC6551AccountUpgradeable is
         return "";
     }
 
-    function isValidSigner(address signer, bytes calldata) external view virtual returns (bytes4) {
+    function isValidSigner(address signer, bytes calldata) public view virtual returns (bytes4) {
         if (_isValidSigner(signer)) {
             return IERC6551Account.isValidSigner.selector;
         }
@@ -95,7 +95,7 @@ contract ERC6551AccountUpgradeable is
         address,
         uint256 receivedTokenId,
         bytes memory
-    ) external view virtual returns (bytes4) {
+    ) public view virtual returns (bytes4) {
         _revertIfOwnershipCycle(msg.sender, receivedTokenId);
         return IERC721Receiver.onERC721Received.selector;
     }
@@ -106,7 +106,7 @@ contract ERC6551AccountUpgradeable is
         uint256,
         uint256,
         bytes memory
-    ) external pure virtual returns (bytes4) {
+    ) public pure virtual returns (bytes4) {
         return IERC1155Receiver.onERC1155Received.selector;
     }
 
@@ -116,11 +116,11 @@ contract ERC6551AccountUpgradeable is
         uint256[] memory,
         uint256[] memory,
         bytes memory
-    ) external pure virtual returns (bytes4) {
+    ) public pure virtual returns (bytes4) {
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 
-    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
         return (interfaceId == type(IERC6551Account).interfaceId ||
             interfaceId == type(IERC6551Executable).interfaceId ||
             interfaceId == type(IERC1155Receiver).interfaceId ||

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc6551/reference",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "files": [
     "**/*.sol"
   ],


### PR DESCRIPTION
The examples in the repo, despite being basic, are correct and safe and can be used as a solid base to build more advanced contracts. In order to do so, the functions must be virtual, so that they can be overridden.

@jaydenwindle This PR adds `virtual` to the functions' signatures, making them also `public` so they can be called as super.