### PR TITLE
Optimize initcode

### DIFF
--- a/src/ERC6551Registry.sol
+++ b/src/ERC6551Registry.sol
@@ -81,7 +81,7 @@ contract ERC6551Registry is IERC6551Registry {
             calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
             mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
             mstore(0x5d, implementation) // implementation
-            mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+            mstore(0x49, 0x60ad80600a3d396000f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
 
             // Copy create2 computation data to memory
             mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytedcode)
@@ -144,7 +144,7 @@ contract ERC6551Registry is IERC6551Registry {
             calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
             mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
             mstore(0x5d, implementation) // implementation
-            mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+            mstore(0x49, 0x60ad80600a3d396000f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
 
             // Copy create2 computation data to memory
             mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytedcode)

--- a/src/lib/ERC6551BytecodeLib.sol
+++ b/src/lib/ERC6551BytecodeLib.sol
@@ -23,7 +23,7 @@ library ERC6551BytecodeLib {
             mstore(add(result, 0x57), salt)
             mstore(add(result, 0x37), 0x5af43d82803e903d91602b57fd5bf3)
             mstore(add(result, 0x28), implementation)
-            mstore(add(result, 0x14), 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73)
+            mstore(add(result, 0x14), 0x60ad80600a3d396000f3363d3d373d3d3d363d73)
             mstore(result, 0xb7) // Store the length
             mstore(0x40, add(result, 0xd7)) // Allocate the memory
         }

--- a/test/ERC6551BytecodeLib.t.sol
+++ b/test/ERC6551BytecodeLib.t.sol
@@ -18,7 +18,7 @@ contract ERC6551AccountLibTest is Test {
             implementation, salt, chainId, tokenContract, tokenId
         );
         bytes memory expected = abi.encodePacked(
-            hex"3d60ad80600a3d3981f3363d3d373d3d3d363d73",
+            hex"60ad80600a3d396000f3363d3d373d3d3d363d73",
             implementation,
             hex"5af43d82803e903d91602b57fd5bf3",
             abi.encode(salt, chainId, tokenContract, tokenId)


### PR DESCRIPTION
Just OCD.

Saves 2 gas. The initcode is still of the same length.

Could use `CALLVALUE` (i.e. `msg.value`) instead of `PUSH1 00`, but `PUSH1 00` gives the same length.

Not sure if you want to make `createAccount` payable and pass in the `msg.value` into the newly created account (might be convenient for cases where people want to make accounts with some ETH). Payable methods cost less gas, since they don't have the check for zero `msg.value`. But then we have to handle the case where the account has been already created, possibly sending the `msg.value` into the account.

Before:
```
| Opcode     | Mnemonic       | Stack          | Memory                 |
| ---------- | -------------- | -------------- | ---------------------- |
| 3d         | RETURNDATASIZE | 00             |                        |
| 60 runSize | PUSH1 ad       | ad 00          |                        |
| 80         | DUP1           | ad ad 00       |                        |
| 60 offset  | PUSH1 0a       | 0a ad ad 00    |                        |
| 3d         | RETURNDATASIZE | 00 0a ad ad 00 |                        |
| 39         | CODECOPY       | ad 00          | [00..ad): runtime code |
| 81         | DUP2           | 00 ad 00       | [00..ad): runtime code |
| f3         | RETURN         | 00             | [00..ad): runtime code |
```

After:
```
| Opcode     | Mnemonic       | Stack          | Memory                 |
| ---------- | -------------- | -------------- | ---------------------- |
| 60 runSize | PUSH1 ad       | ad             |                        |
| 80         | DUP1           | ad ad          |                        |
| 60 offset  | PUSH1 0a       | 0a ad ad       |                        |
| 3d         | RETURNDATASIZE | 00 0a ad ad    |                        |
| 39         | CODECOPY       | ad             | [00..ad): runtime code |
| 60 00      | PUSH1 00       | 00 ad          | [00..ad): runtime code |
| f3         | RETURN         |                | [00..ad): runtime code |
```