### PR TITLE
Update for npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## v0.3.1
+
+- Prepare the repo to be published to NPM as `erc6551`, replacing the version published by Cruna (https://github.com/cruna-cc/erc6551)
+- Fix typos in comments
+- Changed pragma to ^0.8.4 as that is the minimum for custom errors
+- Create2.computeAddress -> ERC6551BytecodeLib.computeAddress to remove registry dependency on OpenZeppelin
+- Inluded bytecode_hash in the compilation config as per default to prevent comment vandalism
+
+## v.3.0 (breaking changes)
+
+- Removed the initData parameter to reduce developer confusion and avoid security issues relating to unauthenticated initialization calls
+- Change the type of salt from uint256 to bytes32 to avoid type casting and prevent confusion between the tokenId and chainId uint256 parameters
+- Make salt the second argument of the createAccount and account functions instead of the fifth to more closely align the order of the arguments in calldata to the order of values stored as constants in the bytecode. The order is also changed in the AccountCreated event
+- Modify the operation argument of the execute function to use uint8 instead of uint256 to allow implementations to represent the value of operation as an emum without changing the function signature or execution interface id
+- Rename AccountCreated event to ERC6551AccountCreated to help distinguish 6551-specific events from other account contracts that make use of AccountCreated events
+- Flatten the ERC6551Registry file to make permissionless deployment of the registry easier
+
+## v0.2.2
+
+- Added several helper functions to the ERC6551AccountLib library
+- Removed prettier in favor of forge fmt for formatting
+
+## v0.2.1
+
+- Made examples' functions `virtual` and `public` so that the examples can be used as a base for more advanced contracts

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For the most recently deployed version of these contracts, see the [v0.3.0](http
 
 ## Using as a Dependency
 
-### If you use Forge
+### Foundry
 
 If you want to use `erc6551/reference` as a dependency in another project, you can add it using `forge install`:
 
@@ -20,13 +20,14 @@ forge install erc6551=erc6551/reference
 
 This will add `erc6551/reference` as a git submodule in your project. For more information on managing dependencies, refer to the [Foundry dependencies guide](https://github.com/foundry-rs/book/blob/master/src/projects/dependencies.md).
 
-### If you use Hardhat
+### Hardhat
 
 ```sh
 npm install erc6551 @openzeppelin/contracts
 ```
 
 and use, for example, as
+
 ```
 import "erc6551/interfaces/IERC6551Account.sol";
 ```
@@ -57,31 +58,3 @@ forge test
 ```
 
 For more information on writing and running tests, refer to the [Foundry testing guide](https://github.com/foundry-rs/book/blob/master/src/forge/writing-tests.md).
-
-## History
-
-**0.3.3**
-- prepare the repo to be published to NPM as `erc6551`, replacing the version published by Cruna (https://github.com/cruna-cc/erc6551)
-
-**0.3.2**
-- fix typos in comments
-
-**0.3.1**
-- pragma has been changed to ^0.8.4; is the minimum for custom errors.
-- Create2.computeAddress -> ERC6551BytecodeLib.computeAddress so that it is actually a single file. This makes it easier to verify in case OZ updates their code, such as bumping their solidity pragma. I'd recommend including the bytecode hash in the compilation config as per default to prevent comment vandalism.
-
-**0.3.0** (breaking changes)
-- Remove the initData parameter - this has been a major source of confusion for folks building with 6551, as it is not clear what the value of initData should be. Additionally, this has been brought up as a potential security footgun in both audits we've done, as users may not be aware that the data passed to a 6551 implementation via initData is unauthenticated. For these reasons this parameter is being removed in favor of encouraging folks to use multicall for creation of accounts that require initialization.
-- Change the type of salt from uint256 to bytes32 - this small change means that salt does not need to be type casted inside the account and createAccount functions, and prevents confusion between the tokenId and chainId uint256 parameters
-- Make salt the second argument of the createAccount and account functions instead of the fifth - this more closely aligns the order of the arguments in calldata to the order of values stored as constants in the bytecode. The order is also changed in the AccountCreated event
-- Modify the operation argument of the execute function to use uint8 instead of uint256 - this allows implementations to use an enum to represent the value of operation without changing the function signature or execution interface id
-- Rename AccountCreated event to ERC6551AccountCreated - this change helps distinguish 6551-specific events from other account contracts that make use of AccountCreated events (some folks have been confused by this)
-- Flatten the ERC6551Registry file - this makes permissionless deployment of the registry easier as the exact source code can be included in the EIP rather than having it split across multiple files and relying on a developer's local environment to compile it properly
-
-**0.2.2**
-- Adds several helper functions to the ERC6551AccountLib library
-- Removes prettier in favor of forge fmt for formatting.
-
-**0.2.1**
-
-- Making examples' functions `virtual` and `public` so that the examples can be used as a base for more advanced contracts

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For the most recently deployed version of these contracts, see the [v0.3.0](http
 
 ## Using as a Dependency
 
+### If you use Forge
+
 If you want to use `erc6551/reference` as a dependency in another project, you can add it using `forge install`:
 
 ```sh
@@ -17,6 +19,17 @@ forge install erc6551=erc6551/reference
 ```
 
 This will add `erc6551/reference` as a git submodule in your project. For more information on managing dependencies, refer to the [Foundry dependencies guide](https://github.com/foundry-rs/book/blob/master/src/projects/dependencies.md).
+
+### If you use Hardhat
+
+```sh
+npm install erc6551 @openzeppelin/contracts
+```
+
+and use, for example, as
+```
+import "erc6551/interfaces/IERC6551Account.sol";
+```
 
 ## Development Setup
 
@@ -46,6 +59,28 @@ forge test
 For more information on writing and running tests, refer to the [Foundry testing guide](https://github.com/foundry-rs/book/blob/master/src/forge/writing-tests.md).
 
 ## History
+
+**0.3.3**
+- prepare the repo to be published to NPM as `erc6551`, replacing the version published by Cruna (https://github.com/cruna-cc/erc6551)
+
+**0.3.2**
+- fix typos in comments
+
+**0.3.1**
+- pragma has been changed to ^0.8.4; is the minimum for custom errors.
+- Create2.computeAddress -> ERC6551BytecodeLib.computeAddress so that it is actually a single file. This makes it easier to verify in case OZ updates their code, such as bumping their solidity pragma. I'd recommend including the bytecode hash in the compilation config as per default to prevent comment vandalism.
+
+**0.3.0** (breaking changes)
+- Remove the initData parameter - this has been a major source of confusion for folks building with 6551, as it is not clear what the value of initData should be. Additionally, this has been brought up as a potential security footgun in both audits we've done, as users may not be aware that the data passed to a 6551 implementation via initData is unauthenticated. For these reasons this parameter is being removed in favor of encouraging folks to use multicall for creation of accounts that require initialization.
+- Change the type of salt from uint256 to bytes32 - this small change means that salt does not need to be type casted inside the account and createAccount functions, and prevents confusion between the tokenId and chainId uint256 parameters
+- Make salt the second argument of the createAccount and account functions instead of the fifth - this more closely aligns the order of the arguments in calldata to the order of values stored as constants in the bytecode. The order is also changed in the AccountCreated event
+- Modify the operation argument of the execute function to use uint8 instead of uint256 - this allows implementations to use an enum to represent the value of operation without changing the function signature or execution interface id
+- Rename AccountCreated event to ERC6551AccountCreated - this change helps distinguish 6551-specific events from other account contracts that make use of AccountCreated events (some folks have been confused by this)
+- Flatten the ERC6551Registry file - this makes permissionless deployment of the registry easier as the exact source code can be included in the EIP rather than having it split across multiple files and relying on a developer's local environment to compile it properly
+
+**0.2.2**
+- Adds several helper functions to the ERC6551AccountLib library
+- Removes prettier in favor of forge fmt for formatting.
 
 **0.2.1**
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "erc6551-reference",
-  "version": "0.2.1",
+  "name": "erc6551",
+  "version": "0.3.3",
   "scripts": {
     "test": "forge test",
     "format": "forge fmt",
     "lint": "solhint -w 0 'contracts/**/*.sol'"
   },
-  "dependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/erc6551/reference.git"
+  },
   "devDependencies": {
     "solhint": "^3.3.7"
   }

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cp README.md src/README.md
+cd src
+npm publish
+rm README.md
+cd ..

--- a/script/verify-package-json-in-sync.js
+++ b/script/verify-package-json-in-sync.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const pkg = require("../package.json");
+const pkgc = require("../src/package.json");
+
+if (pkg.version !== pkgc.version) {
+  console.error("package.json and contracts/package.json are out of sync");
+  process.exit(1);
+}

--- a/script/verify-package-json-in-sync.js
+++ b/script/verify-package-json-in-sync.js
@@ -4,6 +4,6 @@ const pkg = require("../package.json");
 const pkgc = require("../src/package.json");
 
 if (pkg.version !== pkgc.version) {
-  console.error("package.json and contracts/package.json are out of sync");
+  console.error("package.json and src/package.json are out of sync");
   process.exit(1);
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@erc6551/reference",
-  "version": "0.2.1",
+  "name": "erc6551",
+  "version": "0.3.3",
   "files": [
-    "**/*.sol"
+    "**/*.sol",
+    "README.md"
   ],
-  "description": "ERC-6551 reference implementation"
+  "description": "ERC-6551 reference implementation",
+  "scripts": {
+    "prepublishOnly": "../script/verify-package-json-in-sync.js"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,13 +303,6 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 minimatch@^5.0.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
@@ -351,16 +344,7 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-prettier-plugin-solidity@^1.0.0-beta.19:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz#9a35124f578404caf617634a8cab80862d726cba"
-  integrity sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==
-  dependencies:
-    "@solidity-parser/parser" "^0.16.0"
-    semver "^7.3.8"
-    solidity-comments-extractor "^0.0.7"
-
-prettier@^2.6.2, prettier@^2.8.3:
+prettier@^2.8.3:
   version "2.8.7"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
   integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
@@ -384,13 +368,6 @@ semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -425,11 +402,6 @@ solhint@^3.3.7:
     text-table "^0.2.0"
   optionalDependencies:
     prettier "^2.8.3"
-
-solidity-comments-extractor@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
-  integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
 string-width@^4.2.3:
   version "4.2.3"
@@ -488,8 +460,3 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
This PR sets up the repo so that it can replace the current npm package published as erc6551.
In order to make clear that it introduces breaking changes, it moves the version to 0.3.x.
It also adds details in the README about the changes.

PS. I am not 100% sure that npm publish will overwrite the existing package without issues. If not I will make a following PR to fix it.