### PR TITLE
Adding ERC-777

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Add support for ERC-777 tokens
+
 ## v0.3.1
 
 - Prepare the repo to be published to NPM as `erc6551`, replacing the version published by Cruna (https://github.com/cruna-cc/erc6551)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "forge test",
     "format": "forge fmt",
     "lint": "solhint -w 0 'contracts/**/*.sol'",
-    "publish-package": "script/publish.sh"
+    "publish-package": "script/publish.sh",
+    "prepublishOnly": "echo 'ERROR: Use script/publish.sh to publish' && exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc6551",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "test": "forge test",
     "format": "forge fmt",

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -123,19 +123,19 @@ contract ERC6551AccountUpgradeable is
     }
 
     function tokensReceived(address, address, address, uint256, bytes calldata, bytes calldata)
-    external
-    virtual
-    override
+        external
+        virtual
+        override
     {}
 
     function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
         return (
             interfaceId == type(IERC6551Account).interfaceId
-            || interfaceId == type(IERC6551Executable).interfaceId
-            || interfaceId == type(IERC1155Receiver).interfaceId
-            || interfaceId == type(IERC721Receiver).interfaceId
-            || interfaceId == type(IERC777Recipient).interfaceId
-            || interfaceId == type(IERC165).interfaceId
+                || interfaceId == type(IERC6551Executable).interfaceId
+                || interfaceId == type(IERC1155Receiver).interfaceId
+                || interfaceId == type(IERC721Receiver).interfaceId
+                || interfaceId == type(IERC777Recipient).interfaceId
+                || interfaceId == type(IERC165).interfaceId
         );
     }
 

--- a/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
+++ b/src/examples/upgradeable/ERC6551AccountUpgradeable.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/StorageSlot.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/token/ERC777/ERC777.sol";
 
 import "../../interfaces/IERC6551Account.sol";
 import "../../interfaces/IERC6551Executable.sol";
@@ -24,6 +25,7 @@ contract ERC6551AccountUpgradeable is
     IERC165,
     IERC721Receiver,
     IERC1155Receiver,
+    IERC777Recipient,
     IERC6551Account,
     IERC6551Executable,
     IERC1271
@@ -120,13 +122,20 @@ contract ERC6551AccountUpgradeable is
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 
+    function tokensReceived(address, address, address, uint256, bytes calldata, bytes calldata)
+    external
+    virtual
+    override
+    {}
+
     function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
         return (
             interfaceId == type(IERC6551Account).interfaceId
-                || interfaceId == type(IERC6551Executable).interfaceId
-                || interfaceId == type(IERC1155Receiver).interfaceId
-                || interfaceId == type(IERC721Receiver).interfaceId
-                || interfaceId == type(IERC165).interfaceId
+            || interfaceId == type(IERC6551Executable).interfaceId
+            || interfaceId == type(IERC1155Receiver).interfaceId
+            || interfaceId == type(IERC721Receiver).interfaceId
+            || interfaceId == type(IERC777Recipient).interfaceId
+            || interfaceId == type(IERC165).interfaceId
         );
     }
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc6551",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "files": [
     "**/*.sol",
     "README.md"

--- a/test/examples/upgradeable/ERC6551AccountUpgradeable.t.sol
+++ b/test/examples/upgradeable/ERC6551AccountUpgradeable.t.sol
@@ -287,14 +287,13 @@ contract AccountProxyTest is Test {
         assertEq(address(uint160(uint256(rawImplementation))), address(0));
 
         // Send ETH to initialize.
-        (bool success, ) = payable(account).call{value: 0}("");
+        (bool success,) = payable(account).call{value: 0}("");
         assertTrue(success);
 
         rawImplementation =
             vm.load(account, 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
 
         assertEq(address(uint160(uint256(rawImplementation))), address(implementation));
-        
     }
 
     function testERC721Receive() public {


### PR DESCRIPTION
The standard tokens included in OpenZeppelin suite are ERC20, ERC731, ERC1155 and ERC777. The latter is missed in this reference implementation. This PR adds support for it.

_Notice that I didn't add a test for it because I don't really know how to test using forge. However, the implementation is minimalistic and I have tested that specific code in other projects._
_Of course, if someone would like to add a test, it would be great._
