### PR TITLE
Avoid unintentional direct publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "forge test",
     "format": "forge fmt",
     "lint": "solhint -w 0 'contracts/**/*.sol'",
-    "publish-package": "script/publish.sh"
+    "publish-package": "script/publish.sh",
+    "prepublishOnly": "echo 'ERROR: Use script/publish.sh to publish' && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@jaydenwindle We use `script/publish.sh` to optimize the publishing of the package. Still, it is possible to call directly `npm publish` which would create a conflict in projects using erc6551. Adding a `prepublishOnly` in package.json we can prevent it.